### PR TITLE
Test Fortran support

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,19 +10,18 @@ export PYTHON=
 export LDFLAGS="$LDFLAGS -L$PREFIX/lib -Wl,-rpath,$PREFIX/lib"
 export CFLAGS="$CFLAGS -fPIC -I$PREFIX/include"
 
-src_dir="$(pwd)"
-mkdir ../build
-cd ../build
-cmake $src_dir \
-         -DCMAKE_INSTALL_PREFIX=$PREFIX \
-         -DENABLE_JPG=1 \
-         -DENABLE_NETCDF=1 \
-         -DENABLE_PNG=1 \
-         -DENABLE_PYTHON=0 \
-         -DENABLE_FORTRAN=0
+# Shared.
+mkdir build_ecmwf_grib && cd build_ecmwf_grib
+cmake -D CMAKE_INSTALL_PREFIX=$PREFIX \
+      -D ENABLE_JPG=1 \
+      -D ENABLE_NETCDF=1 \
+      -D ENABLE_PNG=1 \
+      -D ENABLE_FORTRAN=1 \
+      -D ENABLE_PYTHON=0 \
+      $SRC_DIR
+
 
 make
-export ECCODES_TEST_VERBOSE_OUTPUT=1
 eval ${LIBRARY_SEARCH_VAR}=$PREFIX/lib
 ctest
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,17 +20,26 @@ requirements:
         - jasper
         - libpng >=1.6.21,<1.7
         - libnetcdf 4.4.*
+        - gcc
+        - isl 0.12.*
     run:
         - jasper
         - libpng >=1.6.21,<1.7
         - libnetcdf 4.4.*
+        - libgcc
+        - isl 0.12.*
 
 test:
     commands:
         - grib_info
         - ls $(grib_info -t)
         - ls $(grib_info -d)
-
+        - test -f ${PREFIX}/lib/libgrib_api.so  # [linux]
+        - test -f ${PREFIX}/lib/libgrib_api_f77.so  # [linux]
+        - test -f ${PREFIX}/lib/libgrib_api_f90.so  # [linux]
+        - test -f ${PREFIX}/lib/libgrib_api.dylib  # [osx]
+        - test -f ${PREFIX}/lib/libgrib_api_f77.dylib  # [osx]
+        - test -f ${PREFIX}/lib/libgrib_api_f90.dylib  # [osx]
 about:
     home: https://software.ecmwf.int/wiki/display/GRIB/Home
     license: Apache-2.0


### PR DESCRIPTION
We are stuck with the `default` channel `gcc` for Fortran modules, not sure if there is a better approach in sight.

Closes #8