### PR TITLE
Pin to libnetcdf 4.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     md5: b3caa51fd2c2ae6e4e304e570489074f
 
 build:
-    number: 3
+    number: 4
     skip: True  # [win]
     detect_binary_files_with_prefix: true
 
@@ -18,11 +18,11 @@ requirements:
     build:
         - jasper
         - libpng 1.6*
-        - libnetcdf 4.3*
+        - libnetcdf 4.4*
     run:
         - jasper
         - libpng 1.6*
-        - libnetcdf 4.3*
+        - libnetcdf 4.4*
 
 test:
     commands:


### PR DESCRIPTION
Let's wait for https://github.com/conda-forge/libnetcdf-feedstock/pull/1 to be merged first before merging this one.