### PR TITLE
Test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ before_install:
 
 install:
     - |
-      MINICONDA_URL="http://repo.continuum.io/miniconda"
+      MINICONDA_URL="https://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
       source /Users/travis/miniconda3/bin/activate root

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 
-if [[ $(uname) == Darwin ]]; then
-  export LIBRARY_SEARCH_VAR=DYLD_FALLBACK_LIBRARY_PATH
-elif [[ $(uname) == Linux ]]; then
-  export LIBRARY_SEARCH_VAR=LD_LIBRARY_PATH
-fi
-
 export PYTHON=
 export LDFLAGS="$LDFLAGS -L$PREFIX/lib -Wl,-rpath,$PREFIX/lib"
 export CFLAGS="$CFLAGS -fPIC -I$PREFIX/include"
@@ -22,6 +16,5 @@ cmake -D CMAKE_INSTALL_PREFIX=$PREFIX \
 
 
 make
-eval ${LIBRARY_SEARCH_VAR}=$PREFIX/lib
 ctest
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 0068ca4149a9f991d4c86a813ac73b4e2299c6a3fd53aba9e6ab276ef6f0ff9a
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win]
   detect_binary_files_with_prefix: true
 
@@ -25,7 +25,8 @@ requirements:
     - jasper
     - libpng >=1.6.23,<1.7
     - libnetcdf 4.4.*
-    - libgfortran
+    - libgcc  # [linux]
+    - libgfortran  # [osx]
 
 test:
   commands:


### PR DESCRIPTION
We were missing `libquadmath` on Linux, but I added a few extra tests in here to see if we still need to export `DYLD_FALLBACK_LIBRARY_PATH` for the thet part.