### PR TITLE
Update pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ To manage the continuous integration and simplify feedstock maintenance
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
+For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,12 +5,11 @@ package:
   version: {{ version }}
 
 source:
-  fn: grib_api-{{ version }}.tar.gz
   url: https://software.ecmwf.int/wiki/download/attachments/3473437/grib_api-{{ version }}-Source.tar.gz
   sha256: 7b0c40bcc8794ee11385bd6b9c5230a23e2432c88c8203dfdc7ccee054535ad4
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win]
   detect_binary_files_with_prefix: true
 
@@ -18,12 +17,12 @@ requirements:
   build:
     - cmake
     - jasper
-    - libpng >=1.6.28,<1.7
+    - libpng >=1.6.22,<1.6.31
     - libnetcdf 4.4.*
     - gcc
   run:
     - jasper
-    - libpng >=1.6.28,<1.7
+    - libpng >=1.6.22,<1.6.31
     - libnetcdf 4.4.*
     - libgcc  # [linux]
     - libgfortran  # [osx]
@@ -39,8 +38,8 @@ test:
     - test -f ${PREFIX}/lib/libgrib_api.dylib  # [osx]
     - test -f ${PREFIX}/lib/libgrib_api_f77.dylib  # [osx]
     - test -f ${PREFIX}/lib/libgrib_api_f90.dylib  # [osx]
-    - conda inspect linkages -p $PREFIX ecmwf_grib  # [not win]
-    - conda inspect objects -p $PREFIX ecmwf_grib  # [osx]
+    - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
+    - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
 
 about:
   home: https://software.ecmwf.int/wiki/display/GRIB/Home


### PR DESCRIPTION
The rebuild should pick latest `hdf5` and fix https://github.com/conda-forge/pygrib-feedstock/issues/19